### PR TITLE
Add Querydsl build integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,13 @@ plugins {
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 // Spring Boot 3.x는 최소 Java 17을 요구하므로 sourceCompatibility를 17로 업데이트합니다.
@@ -76,15 +83,21 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl {
+        extendsFrom annotationProcessor
+        extendsFrom compileClasspath
+    }
 }
 
 // Querydsl 설정
-def querydslDir = "$buildDir/generated/querydsl"
-
 sourceSets {
     main.java.srcDir querydslDir
 }
 
 tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+tasks.named('compileQuerydsl').configure {
     options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }


### PR DESCRIPTION
## Summary
- configure Querydsl directory and extension
- extend Querydsl configuration from annotationProcessor and compileClasspath
- register compileQuerydsl task with generated sources

## Testing
- `gradle tasks --all | grep -i querydsl`
- `gradle build -x test` *(fails: Annotation processor not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b90e04c832495cf9f150a94365c