### PR TITLE
Add item image metadata API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     // Querydsl 관련 의존성
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 
     // JWT (중복 제거)
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/src/main/java/com/example/weblogin/controller/SellerPageController.java
+++ b/src/main/java/com/example/weblogin/controller/SellerPageController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.weblogin.domain.dto.request.ItemCreateRequest;
+import com.example.weblogin.domain.dto.FileDTO;
 import com.example.weblogin.domain.item.Item;
 import com.example.weblogin.domain.member.Member;
 
@@ -120,10 +121,20 @@ public class SellerPageController {
 	 * 사용자 (Seller)정보 수정 페이지 - 사용자 정보 업데이트
 	 * @return
 	 */
-	@PostMapping("/sellerInfoUpdate")
-	public ResponseEntity<?> updateSellerInfo(@Valid @RequestBody SellerInfoUpdateRequest requestDTO) {
-		Member member = MemberService.getCurrentUserMember();//세션에서 데이터 조회
-		memberService.updateSellerInfo(member, requestDTO);
-		return ResponseEntity.ok(member);
-	}
+        @PostMapping("/sellerInfoUpdate")
+        public ResponseEntity<?> updateSellerInfo(@Valid @RequestBody SellerInfoUpdateRequest requestDTO) {
+                Member member = MemberService.getCurrentUserMember();//세션에서 데이터 조회
+                memberService.updateSellerInfo(member, requestDTO);
+                return ResponseEntity.ok(member);
+        }
+
+        /**
+         * 특정 상품의 이미지 메타데이터 조회
+         * @param itemId 조회할 상품 ID
+         * @return 이미지 메타데이터 목록
+         */
+        @GetMapping("/item/{itemId}/images")
+        public List<FileDTO> getItemImages(@PathVariable Long itemId) {
+                return sellerPageService.getItemImages(itemId);
+        }
 }

--- a/src/main/java/com/example/weblogin/service/SellerPageService.java
+++ b/src/main/java/com/example/weblogin/service/SellerPageService.java
@@ -134,15 +134,29 @@ public class SellerPageService {
 	 * 상품 판매 재개
 	 */
 	@Transactional
-	public void resumeSellingItem(Long itemId) {
-		Item item = itemRepository.findById(itemId).orElseThrow(ItemNotFoundException::new);
+        public void resumeSellingItem(Long itemId) {
+                Item item = itemRepository.findById(itemId).orElseThrow(ItemNotFoundException::new);
 
-		if (item.getItemSellStatus() == ItemSellStatus.NOT_SALE
-			|| item.getItemSellStatus() == ItemSellStatus.SOLD_OUT) {
-			item.updateSellStatus(ItemSellStatus.SELL);
-		} else {
-			throw new IllegalArgumentException("이미 판매중인 상품입니다.");
-		}
+                if (item.getItemSellStatus() == ItemSellStatus.NOT_SALE
+                        || item.getItemSellStatus() == ItemSellStatus.SOLD_OUT) {
+                        item.updateSellStatus(ItemSellStatus.SELL);
+                } else {
+                        throw new IllegalArgumentException("이미 판매중인 상품입니다.");
+                }
 
-	}
+        }
+
+        /**
+         * 상품의 이미지 메타데이터 조회
+         * @param itemId 상품 ID
+         * @return 이미지 메타데이터 목록
+         */
+        @Transactional(readOnly = true)
+        public List<FileDTO> getItemImages(Long itemId) {
+                Item item = itemRepository.findById(itemId)
+                        .orElseThrow(ItemNotFoundException::new);
+                return item.getItemImages().stream()
+                        .map(FileDTO::toDTO)
+                        .collect(Collectors.toList());
+        }
 }

--- a/src/test/java/com/example/weblogin/controller/SellerPageControllerTest.java
+++ b/src/test/java/com/example/weblogin/controller/SellerPageControllerTest.java
@@ -1,0 +1,49 @@
+package com.example.weblogin.controller;
+
+import com.example.weblogin.domain.dto.FileDTO;
+import com.example.weblogin.service.FileService;
+import com.example.weblogin.service.ItemService;
+import com.example.weblogin.service.MemberService;
+import com.example.weblogin.service.SellerPageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SellerPageController.class)
+class SellerPageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SellerPageService sellerPageService;
+    @MockBean
+    private ItemService itemService;
+    @MockBean
+    private MemberService memberService;
+    @MockBean
+    private FileService fileService;
+
+    @Test
+    void getItemImages_ReturnsFileList() throws Exception {
+        List<FileDTO> files = List.of(
+                FileDTO.builder().id(1L).oriImgName("img1.png").build(),
+                FileDTO.builder().id(2L).oriImgName("img2.png").build()
+        );
+        when(sellerPageService.getItemImages(1L)).thenReturn(files);
+
+        mockMvc.perform(get("/seller/item/1/images"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].oriImgName").value("img1.png"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `/seller/item/{itemId}/images` endpoint
- fetch image metadata via service
- add annotation processor dependency for Jakarta
- create controller test for the new API

## Testing
- `gradle test -x compileQuerydsl`

------
https://chatgpt.com/codex/tasks/task_e_684b8b91ce1c8324a3542fd02cc2dedd