### PR TITLE
Fix Querydsl configuration to use Jakarta imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
 
-    // Querydsl 관련 의존성
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    // Querydsl 관련 의존성 (Jakarta)
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 

--- a/src/main/java/com/example/weblogin/config/QuerydslConfig.java
+++ b/src/main/java/com/example/weblogin/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.weblogin.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## Summary
- configure Querydsl dependencies to use the Jakarta variant
- add missing `QuerydslConfig` with `jakarta.persistence` imports

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684bb346e84483249d31331ff1d7bf80